### PR TITLE
update build to latest duckdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ BUILD_FLAGS=-DEXTENSION_STATIC_BUILD=1 -DBUILD_TPCH_EXTENSION=1 -DBUILD_PARQUET_
 CLIENT_FLAGS :=
 
 # These flags will make DuckDB build the extension
-EXTENSION_FLAGS=-DDUCKDB_OOT_EXTENSION_NAMES="odbc_scanner" -DDUCKDB_OOT_EXTENSION_ODBC_SCANNER_PATH="$(PROJ_DIR)" -DDUCKDB_OOT_EXTENSION_ODBC_SCANNER_SHOULD_LINK="TRUE" -DDUCKDB_OOT_EXTENSION_ODBC_SCANNER_INCLUDE_PATH="$(PROJ_DIR)src/include"
+EXT_NAME="odbc_scanner"
+EXT_NAME_UPPERCASE=$(shell echo $(EXT_NAME) | tr '[:lower:]' '[:upper:]')
+EXTENSION_FLAGS=-DDUCKDB_EXTENSION_NAMES=${EXT_NAME} -DDUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_PATH="$(PROJ_DIR)" -DDUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_SHOULD_LINK="TRUE" -DDUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_LOAD_TESTS="FALSE" -DDUCKDB_EXTENSION_${EXT_NAME_UPPERCASE}_INCLUDE_PATH="$(PROJ_DIR)src/include"
 
 pull:
 	git submodule init
@@ -36,13 +38,13 @@ clean:
 
 # Main build
 debug:
-	mkdir -p  build/debug && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(EXTENSION_FLAGS) ${CLIENT_FLAGS} -DEXTENSION_STATIC_BUILD=1 -DCMAKE_BUILD_TYPE=Debug ${BUILD_FLAGS} -S ./duckdb/ -B build/debug && \
+	mkdir -p build/debug && \
+	cmake $(GENERATOR) $(FORCE_COLOR) $(EXTENSION_FLAGS) ${CLIENT_FLAGS} -DCMAKE_BUILD_TYPE=Debug ${BUILD_FLAGS} -S ./duckdb/ -B build/debug && \
 	cmake --build build/debug --config Debug
 
 release:
 	mkdir -p build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(EXTENSION_FLAGS) ${CLIENT_FLAGS} -DEXTENSION_STATIC_BUILD=1 -DCMAKE_BUILD_TYPE=Release ${BUILD_FLAGS} -S ./duckdb/ -B build/release && \
+	cmake $(GENERATOR) $(FORCE_COLOR) $(EXTENSION_FLAGS) ${CLIENT_FLAGS} -DCMAKE_BUILD_TYPE=Release ${BUILD_FLAGS} -S ./duckdb/ -B build/release && \
 	cmake --build build/release --config Release
 
 # Client build

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to the correct version of `unixodbc`.
 
 ```shell
 nix run .#build
-./build/release/duckdb
+./build/release/duckdb -unsigned
 ```
 
 To use ODBC DSN's with driver paths managed by the `odbc-drivers-nix` flake run the generate nix apps.

--- a/src/include/odbc_scanner_extension.hpp
+++ b/src/include/odbc_scanner_extension.hpp
@@ -3,7 +3,7 @@
 #include "duckdb.hpp"
 
 namespace duckdb {
-class Odbc_scannerExtension : public Extension {
+class OdbcScannerExtension : public Extension {
 public:
   void Load(DuckDB &db) override;
   std::string Name() override;

--- a/src/odbc_scanner_extension.cpp
+++ b/src/odbc_scanner_extension.cpp
@@ -29,8 +29,8 @@ static void LoadInternal(DatabaseInstance &instance) {
   con.Commit();
 }
 
-void Odbc_scannerExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
-std::string Odbc_scannerExtension::Name() { return "odbc_scanner"; }
+void OdbcScannerExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
+std::string OdbcScannerExtension::Name() { return "odbc_scanner"; }
 } // namespace duckdb
 
 extern "C" {


### PR DESCRIPTION
This is required to build the extension against latest DuckDB version (`v0.8.2-dev2278`)
Don't forget to do a `make pull` to retrieve the updated git submodule of DuckDB